### PR TITLE
cpufreq: cpu-boost: don't boost if input_boost_ms is <= 0

### DIFF
--- a/drivers/cpufreq/cpu-boost.c
+++ b/drivers/cpufreq/cpu-boost.c
@@ -345,6 +345,9 @@ static void do_input_boost(struct work_struct *work)
 	unsigned int i, ret;
 	struct cpu_sync *i_sync_info;
 
+	if (!input_boost_ms)
+		return;
+
 	cancel_delayed_work_sync(&input_boost_rem);
 	if (sched_boost_active) {
 		sched_set_boost(0);


### PR DESCRIPTION
Signed-off-by: Francisco Franco <franciscofranco.1990@gmail.com>